### PR TITLE
Add windows support

### DIFF
--- a/lkh/__init__.py
+++ b/lkh/__init__.py
@@ -2,6 +2,7 @@ import tsplib95 as tsplib
 import tempfile
 import subprocess
 import shutil
+import os
 
 def solve(solver='LKH', problem=None, **params):
     assert shutil.which(solver) is not None, f'{solver} not found.'
@@ -13,29 +14,36 @@ def solve(solver='LKH', problem=None, **params):
         if len(problem.depots) > 0:
             problem.depots = map(lambda x: f'{x}\n', problem.depots)
 
-        prob_file = tempfile.NamedTemporaryFile(mode='w')
+        prob_file = tempfile.NamedTemporaryFile(mode='w', delete=False)
         problem.write(prob_file)
         prob_file.write('\n')
-        prob_file.flush()
+        prob_file.close()
         params['problem_file'] = prob_file.name
 
     # need dimension of problem to parse solution
     problem = tsplib.load(params['problem_file'])
 
     if 'tour_file' not in params:
-        tour_file = tempfile.NamedTemporaryFile(mode='w')
+        tour_file = tempfile.NamedTemporaryFile(mode='w', delete=False)
         params['tour_file'] = tour_file.name
+        tour_file.close()
 
-    with tempfile.NamedTemporaryFile(mode='w') as par_file:
-        par_file.write('SPECIAL\n')
-        for k, v in params.items():
-            par_file.write(f'{k.upper()} = {v}\n')
-        par_file.flush()
+    par_file = tempfile.NamedTemporaryFile(mode='w+', delete=False)
+    par_file.write('SPECIAL\n')
+    for k, v in params.items():
+        par_file.write(f'{k.upper()} = {v}\n')
+    par_file.close()
 
-        try:
-            subprocess.check_output([solver, par_file.name], stderr=subprocess.STDOUT)
-        except subprocess.CalledProcessError as e:
-            raise Exception(e.output.decode())
+    try:
+        # stdin=DEVNULL for preventing a "Press any key" pause at the end of execution
+        subprocess.check_output([solver, par_file.name], stderr=subprocess.STDOUT, stdin=subprocess.DEVNULL)
+    except subprocess.CalledProcessError as e:
+        raise Exception(e.output.decode())
 
-        solution = tsplib.load(params['tour_file'])
-        return solution.tours
+    solution = tsplib.load(params['tour_file'])
+
+    os.remove(par_file.name)
+    if 'prob_file' in locals(): os.remove(prob_file.name)
+    if 'tour_file' in locals(): os.remove(tour_file.name)
+    
+    return solution.tours


### PR DESCRIPTION
PyLKH was not working on Windows due to this [problem](https://stackoverflow.com/q/18903069/11227118). As the documentation on [NamedTemporaryFile](https://docs.python.org/3/library/tempfile.html#tempfile.NamedTemporaryFile) says:
> "Whether the name can be used to open the file a second time, while the named temporary file is still open, varies across platforms (it can be so used on Unix; it cannot on Windows NT or later)"

I fixed that by following [this solution](https://stackoverflow.com/a/21524063/11227118). Furthermore, I adapted the `subprocess.check_output` call to skip the "Press any key" pause on LKH windows. I tested it on Linux and Windows and both work.