### PR TITLE
Update click version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ packages = [
 
 [tool.poetry.dependencies]
 python = "^3.3"
-Click = "^6.0"
+Click = ">=6.0"
 Deprecated = "~1.2.9"
 networkx = "^2.1"
 tabulate = "~0.8.7"
@@ -25,3 +25,4 @@ twine = "^4.0.2"
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
+ 


### PR DESCRIPTION
Allow for newer versions of `Click` than `6.0` so that `pylkh` could work alongside other packages that require `Click > 7.0.0`.